### PR TITLE
geom_alt props

### DIFF
--- a/data/421/195/189/421195189.geojson
+++ b/data/421/195/189/421195189.geojson
@@ -535,6 +535,9 @@
     },
     "wof:country":"LS",
     "wof:created":1459009835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"975db34e8532f3b3d8cba8abf353e786",
     "wof:hierarchy":[
         {
@@ -545,7 +548,7 @@
         }
     ],
     "wof:id":421195189,
-    "wof:lastmodified":1566596492,
+    "wof:lastmodified":1582347505,
     "wof:name":"Maseru",
     "wof:parent_id":85673827,
     "wof:placetype":"locality",

--- a/data/856/321/73/85632173.geojson
+++ b/data/856/321/73/85632173.geojson
@@ -879,6 +879,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -934,6 +935,10 @@
     },
     "wof:country":"LS",
     "wof:country_alpha3":"LSO",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"e484e6b762c5cbca76d0986dc51eb745",
     "wof:hierarchy":[
         {
@@ -950,7 +955,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1566596472,
+    "wof:lastmodified":1582347504,
     "wof:name":"Lesotho",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/321/73/85632173.geojson
+++ b/data/856/321/73/85632173.geojson
@@ -879,7 +879,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -955,7 +954,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1582347504,
+    "wof:lastmodified":1583227338,
     "wof:name":"Lesotho",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.