### PR TITLE
Name updates

### DIFF
--- a/data/856/321/73/85632173.geojson
+++ b/data/856/321/73/85632173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.845592,
-    "geom:area_square_m":30598378881.45985,
+    "geom:area_square_m":30598378961.294907,
     "geom:bbox":"27.011189,-30.677733,29.456192,-28.570607",
     "geom:latitude":-29.583318,
     "geom:longitude":28.246545,
@@ -52,6 +52,9 @@
     "name:arg_x_preferred":[
         "Lesoto"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u064a\u0633\u0648\u0637\u0648"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u064a\u0633\u0648\u062a\u0648"
     ],
@@ -72,6 +75,9 @@
     ],
     "name:bam_x_preferred":[
         "Lesoto"
+    ],
+    "name:ban_x_preferred":[
+        "Lesotho"
     ],
     "name:bcl_x_preferred":[
         "Lesoto"
@@ -142,6 +148,12 @@
     "name:dan_x_preferred":[
         "Lesotho"
     ],
+    "name:deu_at_x_preferred":[
+        "Lesotho"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Lesotho"
+    ],
     "name:deu_x_preferred":[
         "Lesotho"
     ],
@@ -165,6 +177,12 @@
     ],
     "name:ell_x_variant":[
         "\u039b\u03b5\u03c3\u03cc\u03b8\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Lesotho"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Lesotho"
     ],
     "name:eng_x_preferred":[
         "Lesotho"
@@ -224,6 +242,9 @@
     ],
     "name:gag_x_preferred":[
         "Lesoto"
+    ],
+    "name:gcr_x_preferred":[
+        "L\u00e9soto"
     ],
     "name:ger_x_colloquial":[
         "Koenigreich Lesotho",
@@ -472,11 +493,17 @@
     "name:mon_x_preferred":[
         "\u041b\u0435\u0441\u043e\u0442\u043e"
     ],
+    "name:mri_x_preferred":[
+        "Teroto"
+    ],
     "name:msa_x_preferred":[
         "Lesotho"
     ],
     "name:mya_x_preferred":[
         "\u101c\u102e\u1006\u102d\u102f\u101e\u102d\u102f\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0644\u0633\u0648\u062a\u0648"
     ],
     "name:nah_x_preferred":[
         "Lesoto"
@@ -516,6 +543,9 @@
     ],
     "name:nov_x_preferred":[
         "Lesutu"
+    ],
+    "name:nqo_x_preferred":[
+        "\u07df\u07cc\u07db\u07d5\u07cf\u07eb"
     ],
     "name:nso_x_preferred":[
         "Lesotho"
@@ -566,6 +596,9 @@
         "Lesotho"
     ],
     "name:pol_x_variant":[
+        "Lesoto"
+    ],
+    "name:por_br_x_preferred":[
         "Lesoto"
     ],
     "name:por_x_preferred":[
@@ -619,6 +652,9 @@
     "name:sna_x_preferred":[
         "Lesotho"
     ],
+    "name:snd_x_preferred":[
+        "\u0644\u064a\u0633\u0648\u067f\u0648"
+    ],
     "name:som_x_preferred":[
         "Lesotho"
     ],
@@ -636,6 +672,15 @@
         "Lesotho"
     ],
     "name:sqi_x_preferred":[
+        "Lesoto"
+    ],
+    "name:srd_x_preferred":[
+        "Lesotho"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041b\u0435\u0441\u043e\u0442\u043e"
+    ],
+    "name:srp_el_x_preferred":[
         "Lesoto"
     ],
     "name:srp_x_preferred":[
@@ -660,6 +705,9 @@
         "Lesotho"
     ],
     "name:szl_x_preferred":[
+        "Lesotho"
+    ],
+    "name:szy_x_preferred":[
         "Lesotho"
     ],
     "name:tam_x_preferred":[
@@ -787,8 +835,26 @@
     "name:zha_x_preferred":[
         "Lesotho"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u83b1\u7d22\u6258"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u83b1\u7d22\u6258"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Lesotho"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u83b1\u7d22\u6258"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u83b1\u7d22\u6258"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u83b1\u7d22\u6258"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8cf4\u7d22\u6258"
     ],
     "name:zho_x_preferred":[
         "\u83b1\u7d22\u6258"
@@ -955,7 +1021,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1583797383,
+    "wof:lastmodified":1587428313,
     "wof:name":"Lesotho",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.