### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/168/783/421168783.geojson
+++ b/data/421/168/783/421168783.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0641\u062a\u064a\u0646\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0641\u062a\u064a\u0646\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Mafeteng"
+    ],
     "name:aze_x_preferred":[
         "Mafetenq"
+    ],
+    "name:ceb_x_preferred":[
+        "Mafeteng"
     ],
     "name:deu_x_preferred":[
         "Mafeteng"
@@ -37,6 +46,9 @@
     ],
     "name:frr_x_preferred":[
         "Mafeteng"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e4\u05d8\u05e0\u05d2"
     ],
     "name:hrv_x_preferred":[
         "Mafeteng"
@@ -52,6 +64,9 @@
     ],
     "name:lit_x_preferred":[
         "Mafetengas"
+    ],
+    "name:nau_x_preferred":[
+        "Mafeteng"
     ],
     "name:nld_x_preferred":[
         "Mafeteng"
@@ -91,6 +106,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u8d39\u6ed5"
+    ],
+    "name:zul_x_preferred":[
+        "Mafeteng"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -232,7 +250,7 @@
         }
     ],
     "wof:id":421168783,
-    "wof:lastmodified":1636501496,
+    "wof:lastmodified":1690938599,
     "wof:name":"Mafeteng",
     "wof:parent_id":85673861,
     "wof:placetype":"locality",

--- a/data/421/168/785/421168785.geojson
+++ b/data/421/168/785/421168785.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Hlotse"
     ],
+    "name:ast_x_preferred":[
+        "Hlotse"
+    ],
     "name:ceb_x_preferred":[
         "Leribe"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:hun_x_preferred":[
         "Lerib\u00e8"
+    ],
+    "name:ind_x_preferred":[
+        "Hlotse"
     ],
     "name:ita_x_preferred":[
         "Hlotse"
@@ -103,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83b1\u91cc\u8d1d"
+    ],
+    "name:zul_x_preferred":[
+        "Hlotse"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -241,7 +250,7 @@
         }
     ],
     "wof:id":421168785,
-    "wof:lastmodified":1636501496,
+    "wof:lastmodified":1690938599,
     "wof:name":"Leribe",
     "wof:parent_id":85673843,
     "wof:placetype":"locality",

--- a/data/421/177/165/421177165.geojson
+++ b/data/421/177/165/421177165.geojson
@@ -23,10 +23,19 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0627\u062a\u064a\u0627\u0646\u064a\u0646\u063a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0627\u062a\u064a\u0627\u0646\u064a\u0646\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09c7\u09df\u09be\u09a4\u09c7\u0987\u09df\u09be\u0999\u09cd\u0997\u09c7\u0982"
     ],
     "name:bre_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:cat_x_preferred":[
         "Teyateyaneng"
     ],
     "name:ceb_x_preferred":[
@@ -43,6 +52,9 @@
     ],
     "name:fas_x_preferred":[
         "\u062a\u06cc\u0627\u062a\u06cc\u0627\u0646\u0646\u06af"
+    ],
+    "name:fin_x_preferred":[
+        "Teyateyaneng"
     ],
     "name:fra_x_preferred":[
         "Teyateyaneng"
@@ -61,6 +73,9 @@
     ],
     "name:hun_x_preferred":[
         "Teyateyaneng"
+    ],
+    "name:hye_x_preferred":[
+        "\u054f\u0565\u0575\u0561\u057f\u0565\u0575\u0561\u0576\u0565\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Teyateyaneng"
@@ -86,6 +101,12 @@
     "name:nor_x_preferred":[
         "Teyateyaneng"
     ],
+    "name:nso_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:nya_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:pol_x_preferred":[
         "Teyateyaneng"
     ],
@@ -107,6 +128,9 @@
     "name:swe_x_preferred":[
         "Teyateyaneng"
     ],
+    "name:tum_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:tur_x_preferred":[
         "Teyateyaneng"
     ],
@@ -119,8 +143,17 @@
     "name:vie_x_preferred":[
         "Teyateyaneng"
     ],
+    "name:war_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:xho_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:zho_x_preferred":[
         "\u6cf0\u4e9e\u6cf0\u4e9e\u5ae9"
+    ],
+    "name:zul_x_preferred":[
+        "Teyateyaneng"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -167,7 +200,7 @@
         }
     ],
     "wof:id":421177165,
-    "wof:lastmodified":1636501496,
+    "wof:lastmodified":1690938600,
     "wof:name":"Teyateyaneng",
     "wof:parent_id":85673823,
     "wof:placetype":"locality",

--- a/data/421/177/969/421177969.geojson
+++ b/data/421/177/969/421177969.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Quthing"
     ],
+    "name:ast_x_preferred":[
+        "Quthing"
+    ],
     "name:ceb_x_preferred":[
         "Quthing"
     ],
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421177969,
-    "wof:lastmodified":1636501497,
+    "wof:lastmodified":1690938600,
     "wof:name":"Quthing",
     "wof:parent_id":85673833,
     "wof:placetype":"locality",

--- a/data/421/178/339/421178339.geojson
+++ b/data/421/178/339/421178339.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0643\u0648\u062a\u0644\u0648\u0646\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0643\u0648\u062a\u0644\u0648\u0646\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Mokhotlong"
+    ],
     "name:ceb_x_preferred":[
         "Mokhotlong"
     ],
@@ -30,6 +36,9 @@
         "Mokhotlong"
     ],
     "name:eng_x_preferred":[
+        "Mokhotlong"
+    ],
+    "name:est_x_preferred":[
         "Mokhotlong"
     ],
     "name:fra_x_preferred":[
@@ -64,6 +73,9 @@
     ],
     "name:lit_x_preferred":[
         "Mokotlongas"
+    ],
+    "name:nau_x_preferred":[
+        "Mokhotlong"
     ],
     "name:nld_x_preferred":[
         "Mokhotlong"
@@ -109,6 +121,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u970d\u7279\u9686"
+    ],
+    "name:zul_x_preferred":[
+        "Mokhotlong"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -250,7 +265,7 @@
         }
     ],
     "wof:id":421178339,
-    "wof:lastmodified":1636501497,
+    "wof:lastmodified":1690938600,
     "wof:name":"Mokhotlong",
     "wof:parent_id":85673847,
     "wof:placetype":"locality",

--- a/data/421/179/979/421179979.geojson
+++ b/data/421/179/979/421179979.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0647\u0627\u0644\u064a \u0647\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0647\u0627\u0644\u0649 \u0647\u0648\u0643"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u09b9\u09be\u09b2\u09c7\u09b8 \u09b9\u09cb\u09df\u09c7\u0995"
     ],
@@ -68,6 +71,9 @@
     "name:kor_x_preferred":[
         "\ubaa8\ud560\ub808\uc2a4 \ud6c4\ud06c"
     ],
+    "name:nau_x_preferred":[
+        "Mohale's Hoek"
+    ],
     "name:nld_x_preferred":[
         "Mohale's Hoek"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u54c8\u840a\u65af\u80e1\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Mohale's Hoek"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -248,7 +257,7 @@
         }
     ],
     "wof:id":421179979,
-    "wof:lastmodified":1636501497,
+    "wof:lastmodified":1690938600,
     "wof:name":"Mohales Hoek",
     "wof:parent_id":85673829,
     "wof:placetype":"locality",

--- a/data/421/182/759/421182759.geojson
+++ b/data/421/182/759/421182759.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Maputsoe"
     ],
+    "name:zul_x_preferred":[
+        "Maputsoe"
+    ],
     "qs:gn_country":"LS",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":932521,
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421182759,
-    "wof:lastmodified":1566596494,
+    "wof:lastmodified":1690938601,
     "wof:name":"Maputsoe",
     "wof:parent_id":85673843,
     "wof:placetype":"locality",

--- a/data/421/183/949/421183949.geojson
+++ b/data/421/183/949/421183949.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":6.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Maletsunyane-waterval"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0644\u064a\u062a\u0633\u0648\u0646\u064a\u0627\u0646 \u0641\u0627\u0644\u0633"
+    ],
     "name:cat_x_preferred":[
         "Cascades Maletsunyane"
     ],
@@ -40,6 +46,9 @@
     "name:fra_x_preferred":[
         "Chutes du Maletsunyane"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0561\u056c\u0565\u0581\u0578\u0582\u0576\u0575\u0561\u0576 \u057b\u0580\u057e\u0565\u056a"
+    ],
     "name:jpn_x_preferred":[
         "\u30de\u30ec\u30c4\u30cb\u30e3\u30fc\u30cd\u6edd"
     ],
@@ -48,6 +57,9 @@
     ],
     "name:pol_x_preferred":[
         "Maletsunyane Falls"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u043e\u0434\u043e\u043f\u0430\u0434 \u041c\u0430\u043b\u0435\u0446\u0443\u043d\u044c\u044f\u043d\u0435"
     ],
     "name:spa_x_preferred":[
         "Cataratas Maletsunyane"
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421183949,
-    "wof:lastmodified":1566596493,
+    "wof:lastmodified":1690938600,
     "wof:name":"Maletsunyane",
     "wof:parent_id":85673857,
     "wof:placetype":"county",

--- a/data/421/195/189/421195189.geojson
+++ b/data/421/195/189/421195189.geojson
@@ -28,10 +28,25 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0633\u064a\u0631\u0648"
     ],
+    "name:arg_x_preferred":[
+        "Maseru"
+    ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u0633\u064a\u0631\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0633\u064a\u0631\u0648"
+    ],
     "name:ast_x_preferred":[
         "Maseru"
     ],
+    "name:avk_x_preferred":[
+        "Maseru"
+    ],
     "name:aze_x_preferred":[
+        "Maseru"
+    ],
+    "name:ban_x_preferred":[
         "Maseru"
     ],
     "name:bar_x_preferred":[
@@ -39,6 +54,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0441\u0435\u0440\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u0441\u0435\u0440\u0443"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b8\u09c7\u09b0\u09c1"
@@ -172,6 +190,9 @@
     "name:ile_x_preferred":[
         "Maseru"
     ],
+    "name:ina_x_preferred":[
+        "Maseru"
+    ],
     "name:ind_x_preferred":[
         "Maseru"
     ],
@@ -214,6 +235,9 @@
     "name:lav_x_preferred":[
         "Maseru"
     ],
+    "name:lfn_x_preferred":[
+        "Maseru"
+    ],
     "name:lij_x_preferred":[
         "Maseru"
     ],
@@ -232,6 +256,9 @@
     "name:mar_x_preferred":[
         "\u092e\u093e\u0938\u0947\u0930\u0942"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u0441\u044d\u0440\u0443"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u0441\u0435\u0440\u0443"
     ],
@@ -241,10 +268,16 @@
     "name:msa_x_preferred":[
         "Maseru"
     ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0627\u0633\u0631\u0648"
+    ],
     "name:nah_x_preferred":[
         "Maseru"
     ],
     "name:nan_x_preferred":[
+        "Maseru"
+    ],
+    "name:nau_x_preferred":[
         "Maseru"
     ],
     "name:nds_x_preferred":[
@@ -271,6 +304,9 @@
     "name:oci_x_preferred":[
         "Maseru"
     ],
+    "name:olo_x_preferred":[
+        "Maseru"
+    ],
     "name:oss_x_preferred":[
         "\u041c\u0430\u0441\u0435\u0440\u0443"
     ],
@@ -295,6 +331,9 @@
     "name:pus_x_preferred":[
         "\u0645\u0627\u0633\u0631\u0648"
     ],
+    "name:que_x_preferred":[
+        "Maseru"
+    ],
     "name:ron_x_preferred":[
         "Maseru"
     ],
@@ -316,6 +355,12 @@
     "name:sme_x_preferred":[
         "Maseru"
     ],
+    "name:smn_x_preferred":[
+        "Maseru"
+    ],
+    "name:sms_x_preferred":[
+        "Maseru"
+    ],
     "name:sna_x_preferred":[
         "Maseru"
     ],
@@ -329,6 +374,9 @@
         "Maseru"
     ],
     "name:sqi_x_preferred":[
+        "Maseru"
+    ],
+    "name:srd_x_preferred":[
         "Maseru"
     ],
     "name:srp_x_preferred":[
@@ -402,6 +450,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u585e\u5362"
+    ],
+    "name:zul_x_preferred":[
+        "Maseru"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Lesotho",
@@ -553,7 +604,7 @@
         }
     ],
     "wof:id":421195189,
-    "wof:lastmodified":1636501496,
+    "wof:lastmodified":1690938599,
     "wof:name":"Maseru",
     "wof:parent_id":85673827,
     "wof:placetype":"locality",

--- a/data/421/198/525/421198525.geojson
+++ b/data/421/198/525/421198525.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u062b\u0627 \u0628\u0648\u062b\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u062b\u0627 \u0628\u0648\u062b\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Butha-Buthe"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09c1\u09a5\u09be-\u09ac\u09c1\u09a5\u09c7"
+    ],
+    "name:ceb_x_preferred":[
+        "Butha-Buthe"
     ],
     "name:deu_x_preferred":[
         "Butha-Buthe"
@@ -71,6 +80,9 @@
     "name:ltz_x_preferred":[
         "Butha-Buthe"
     ],
+    "name:nau_x_preferred":[
+        "Butha-Buthe"
+    ],
     "name:nld_x_preferred":[
         "Butha-Buthe"
     ],
@@ -115,6 +127,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5854-\u5e03\u6cf0"
+    ],
+    "name:zul_x_preferred":[
+        "Butha-Buthe"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -256,7 +271,7 @@
         }
     ],
     "wof:id":421198525,
-    "wof:lastmodified":1636501496,
+    "wof:lastmodified":1690938599,
     "wof:name":"Butha-Buthe",
     "wof:parent_id":85673843,
     "wof:placetype":"locality",

--- a/data/856/321/73/85632173.geojson
+++ b/data/856/321/73/85632173.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u041b\u0435\u0441\u043e\u0442\u043e"
+    ],
     "name:ace_x_preferred":[
         "Lesotho"
     ],
@@ -37,14 +40,23 @@
     "name:aka_x_preferred":[
         "L\u025bsutu"
     ],
+    "name:aka_x_variant":[
+        "Lesotho"
+    ],
     "name:als_x_preferred":[
         "Lesotho"
     ],
     "name:amh_x_preferred":[
         "\u120c\u1236\u1276"
     ],
+    "name:ami_x_preferred":[
+        "Lesotho"
+    ],
     "name:ang_x_preferred":[
         "Lesotho"
+    ],
+    "name:anp_x_preferred":[
+        "\u0932\u0947\u0938\u094b\u0925\u094b"
     ],
     "name:ara_x_preferred":[
         "\u0644\u064a\u0633\u0648\u062a\u0648"
@@ -64,6 +76,9 @@
     "name:ast_x_variant":[
         "Lesothu"
     ],
+    "name:avk_x_preferred":[
+        "Lesotoa"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u0633\u0648\u062a\u0648"
     ],
@@ -79,6 +94,9 @@
     "name:ban_x_preferred":[
         "Lesotho"
     ],
+    "name:bar_x_preferred":[
+        "Lesotho"
+    ],
     "name:bcl_x_preferred":[
         "Lesoto"
     ],
@@ -90,6 +108,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0932\u093f\u0938\u094b\u0925\u094b"
+    ],
+    "name:bis_x_preferred":[
+        "Lesoto"
     ],
     "name:bjn_x_preferred":[
         "Lesotho"
@@ -139,10 +160,16 @@
     "name:cor_x_preferred":[
         "Lesotho"
     ],
+    "name:cos_x_preferred":[
+        "Lezotu"
+    ],
     "name:crh_x_preferred":[
         "Lesoto"
     ],
     "name:cym_x_preferred":[
+        "Lesotho"
+    ],
+    "name:dag_x_preferred":[
         "Lesotho"
     ],
     "name:dan_x_preferred":[
@@ -268,6 +295,9 @@
     "name:glv_x_preferred":[
         "Lesoto"
     ],
+    "name:gpe_x_preferred":[
+        "Lesotho"
+    ],
     "name:grn_x_preferred":[
         "Les\u00f3to"
     ],
@@ -276,6 +306,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac7\u0ab8\u0acb\u0aa5\u0acb"
+    ],
+    "name:gur_x_preferred":[
+        "Lesotho"
     ],
     "name:hak_x_preferred":[
         "Lesotho"
@@ -337,6 +370,9 @@
     "name:ilo_x_preferred":[
         "Lesoto"
     ],
+    "name:ilo_x_variant":[
+        "Lesotho"
+    ],
     "name:ina_x_preferred":[
         "Lesotho"
     ],
@@ -354,6 +390,9 @@
     ],
     "name:jav_x_preferred":[
         "Lesotho"
+    ],
+    "name:jav_x_variant":[
+        "L\u00e9sotho"
     ],
     "name:jpn_x_preferred":[
         "\u30ec\u30bd\u30c8"
@@ -442,6 +481,9 @@
     "name:lit_x_preferred":[
         "Lesotas"
     ],
+    "name:lld_x_preferred":[
+        "Lesotho"
+    ],
     "name:lmo_x_preferred":[
         "Lesotho"
     ],
@@ -472,6 +514,12 @@
     "name:mar_x_preferred":[
         "\u0932\u0947\u0938\u094b\u0925\u094b"
     ],
+    "name:mdf_x_preferred":[
+        "\u041b\u044d\u0441\u043e\u0442\u043e"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041b\u0435\u0441\u043e\u0442\u043e"
+    ],
     "name:min_x_preferred":[
         "Lesotho"
     ],
@@ -489,6 +537,9 @@
     ],
     "name:mlt_x_preferred":[
         "Lesoto"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc2\uabe6\uabc1\uabe3\uabca\uabe3"
     ],
     "name:mon_x_preferred":[
         "\u041b\u0435\u0441\u043e\u0442\u043e"
@@ -607,6 +658,9 @@
     "name:que_x_preferred":[
         "Suthusuyu"
     ],
+    "name:rmy_x_preferred":[
+        "Lesotho"
+    ],
     "name:roh_x_preferred":[
         "Lesotho"
     ],
@@ -628,6 +682,9 @@
     "name:san_x_preferred":[
         "\u0932\u0947\u0938\u094b\u0925\u094b"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5e\u1c6e\u1c65\u1c73\u1c5b\u1c77\u1c73"
+    ],
     "name:scn_x_preferred":[
         "Lesothu"
     ],
@@ -636,6 +693,9 @@
     ],
     "name:sgs_x_preferred":[
         "Lesuots"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101c\u1084\u1087\u101e\u1030\u101d\u103a\u1038\u1010\u1030\u101d\u103a\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0dbd\u0dd9\u0dc3\u0ddd\u0dad\u0ddd"
@@ -647,6 +707,12 @@
         "Lesoto"
     ],
     "name:sme_x_preferred":[
+        "Lesotho"
+    ],
+    "name:smn_x_preferred":[
+        "Lesotho"
+    ],
+    "name:sms_x_preferred":[
         "Lesotho"
     ],
     "name:sna_x_preferred":[
@@ -740,11 +806,17 @@
     "name:tir_x_preferred":[
         "\u120c\u1236\u1276"
     ],
+    "name:tok_x_preferred":[
+        "ma Lesoto"
+    ],
     "name:ton_x_preferred":[
         "Lesoto"
     ],
     "name:tpi_x_preferred":[
         "Lesoto"
+    ],
+    "name:trv_x_preferred":[
+        "Lesotho"
     ],
     "name:tsn_x_preferred":[
         "Lesotho"
@@ -754,6 +826,9 @@
     ],
     "name:tuk_x_preferred":[
         "Lesoto"
+    ],
+    "name:tum_x_preferred":[
+        "Lesotho"
     ],
     "name:tur_x_preferred":[
         "Lesotho"
@@ -813,6 +888,9 @@
     ],
     "name:xal_x_preferred":[
         "\u041b\u0435\u0441\u043e\u0442\u0438\u043d \u041d\u0443\u0442\u0433"
+    ],
+    "name:xho_x_preferred":[
+        "ELuSuthu"
     ],
     "name:xmf_x_preferred":[
         "\u10da\u10d4\u10e1\u10dd\u10d7\u10dd"
@@ -1086,7 +1164,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1617827547,
+    "wof:lastmodified":1690938598,
     "wof:name":"Lesotho",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/738/23/85673823.geojson
+++ b/data/856/738/23/85673823.geojson
@@ -86,6 +86,9 @@
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0ab0\u0abf\u0aaf\u0abe \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05e8\u05d0\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u092c\u0940\u0930\u093f\u092f\u093e \u091c\u093f\u0932\u093e"
     ],
@@ -112,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\ub808\uc544 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca0\ub808\uc544\uad6c"
     ],
     "name:lav_x_preferred":[
         "Berjas distrikts"
@@ -178,6 +184,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4f2f\u91cc\u4e9e\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Berea"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -299,7 +308,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501495,
+    "wof:lastmodified":1690938597,
     "wof:name":"Berea",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/27/85673827.geojson
+++ b/data/856/738/27/85673827.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0642\u0627\u0637\u0639\u0629 \u0645\u0627\u0633\u064a\u0631\u0648"
     ],
+    "name:avk_x_preferred":[
+        "LesotoaMaseruUtca"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b8\u09c7\u09b0\u09cb \u099c\u09c7\u09b2\u09be"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0441\u0435\u0440\u0443"
+    ],
+    "name:cat_x_preferred":[
+        "Maseru"
     ],
     "name:ceb_x_preferred":[
         "Maseru"
@@ -65,6 +71,9 @@
     "name:est_x_preferred":[
         "Maseru ringkond"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0645\u0627\u0633\u0631\u0648"
+    ],
     "name:fin_x_preferred":[
         "Maserun alue"
     ],
@@ -89,6 +98,9 @@
     "name:hun_x_preferred":[
         "Maseru"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0561\u057d\u0565\u0580\u0578\u0582"
+    ],
     "name:ind_x_preferred":[
         "Distrik Maseru"
     ],
@@ -106,6 +118,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub9c8\uc138\ub8e8 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub9c8\uc138\ub8e8\uad6c"
     ],
     "name:lav_x_preferred":[
         "Maseru distrikts"
@@ -169,6 +184,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u585e\u76e7\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Maseru"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -290,7 +308,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938596,
     "wof:name":"Maseru",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/29/85673829.geojson
+++ b/data/856/738/29/85673829.geojson
@@ -41,6 +41,9 @@
     "name:bul_x_preferred":[
         "\u041c\u043e\u0445\u0430\u043b\u0435\u0441-\u0425\u0443\u043a"
     ],
+    "name:cat_x_preferred":[
+        "Mohale's Hoek"
+    ],
     "name:ceb_x_preferred":[
         "Mohale's Hoek District"
     ],
@@ -90,6 +93,9 @@
     "name:hun_x_preferred":[
         "Mohale's Hoek"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0578\u0570\u0561\u056c\u0565\u057d \u0540\u0578\u0582\u056f"
+    ],
     "name:ind_x_preferred":[
         "Distrik Mohale's Hoek"
     ],
@@ -107,6 +113,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubaa8\ud560\ub808\uc2a4\ud6c4\ud06c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubaa8\ud560\ub808\uc2a4\ud6c4\ud06c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Mohaleshukas distrikts"
@@ -170,6 +179,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u54c8\u840a\u65af\u80e1\u514b\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Mohale's Hoek"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -291,7 +303,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938596,
     "wof:name":"Mohale's Hoek",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/33/85673833.geojson
+++ b/data/856/738/33/85673833.geojson
@@ -44,6 +44,9 @@
     "name:bul_x_variant":[
         "\u0426\u0433\u0443\u0442\u0438\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Quthing"
+    ],
     "name:ceb_x_preferred":[
         "Quthing"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:eng_x_variant":[
         "Quthing District"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0642\u0648\u062a\u06cc\u0646\u06af"
     ],
     "name:fin_x_preferred":[
         "Quthing"
@@ -106,6 +112,9 @@
     ],
     "name:kor_x_preferred":[
         "\ucfe0\ud305 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ucfe0\ud305\uad6c"
     ],
     "name:lav_x_preferred":[
         "Kuthinas distrikts"
@@ -172,6 +181,9 @@
     ],
     "name:zho_x_preferred":[
         "\u53e4\u5ef7\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Quthing"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -293,7 +305,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938596,
     "wof:name":"Quthing",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/39/85673839.geojson
+++ b/data/856/738/39/85673839.geojson
@@ -41,6 +41,9 @@
     "name:bul_x_preferred":[
         "\u0411\u0443\u0442\u0430-\u0411\u0443\u0442\u0435"
     ],
+    "name:cat_x_preferred":[
+        "Butha Buthe"
+    ],
     "name:ceb_x_preferred":[
         "Butha-Buthe"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:est_x_preferred":[
         "Butha-Buthe ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0628\u0648\u062a\u0627-\u0628\u0648\u062a\u0647"
     ],
     "name:fin_x_preferred":[
         "Butha-Buthen alue"
@@ -103,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubd80\ud0c0\ubd80\ud14c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubd80\ud0c0\ubd80\ud14c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Buthabethes distrikts"
@@ -169,6 +178,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5854-\u5e03\u6cf0\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Butha-Buthe"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -290,7 +302,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501495,
+    "wof:lastmodified":1690938597,
     "wof:name":"Butha-Buthe",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/43/85673843.geojson
+++ b/data/856/738/43/85673843.geojson
@@ -113,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ub808\ub9ac\ubca0 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub808\ub9ac\ubca0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Leribes distrikts"
     ],
@@ -178,6 +181,9 @@
     ],
     "name:zho_x_preferred":[
         "\u840a\u91cc\u8c9d\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Leribe"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -299,7 +305,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938596,
     "wof:name":"Leribe",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/47/85673847.geojson
+++ b/data/856/738/47/85673847.geojson
@@ -41,6 +41,9 @@
     "name:bul_x_preferred":[
         "\u041c\u043e\u043a\u043e\u0442\u043b\u043e\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Mokhotlong"
+    ],
     "name:ceb_x_preferred":[
         "Mokhotlong"
     ],
@@ -62,6 +65,9 @@
     "name:eng_x_variant":[
         "Mokhotlong District"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u0645\u0648\u06a9\u0627\u062a\u200c\u0644\u0627\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Mokhotlong"
     ],
@@ -80,6 +86,9 @@
     "name:hin_x_preferred":[
         "\u092e\u094b\u0916\u094b\u091f\u0932\u093e\u0902\u0917 \u091c\u093f\u0932\u093e"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0578\u056f\u0578\u057f\u056c\u0578\u0576\u0563"
+    ],
     "name:ind_x_preferred":[
         "Distrik Mokhotlong"
     ],
@@ -97,6 +106,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubaa8\ucf54\ud2c0\ub871 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubaa8\ucf54\ud2c0\ub871\uad6c"
     ],
     "name:lav_x_preferred":[
         "Mohothlonas distrikts"
@@ -163,6 +175,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u970d\u7279\u9686\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Mokhotlong"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -284,7 +299,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501495,
+    "wof:lastmodified":1690938597,
     "wof:name":"Mokhotlong",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/51/85673851.geojson
+++ b/data/856/738/51/85673851.geojson
@@ -41,6 +41,9 @@
     "name:bul_x_preferred":[
         "\u0426\u0433\u0430\u0447\u0430\u0441-\u041d\u0435\u043a"
     ],
+    "name:cat_x_preferred":[
+        "Qacha's Nek"
+    ],
     "name:ceb_x_preferred":[
         "Qacha's Nek"
     ],
@@ -60,6 +63,9 @@
         "Qachas Nek",
         "Qacha's Nek District"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0646\u06a9 \u0642\u0686\u0627"
+    ],
     "name:fin_x_preferred":[
         "Qacha'snekin kaupunginosa"
     ],
@@ -74,6 +80,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0aaf\u0ac2\u0a9a\u0abe\u0ab8 \u0aa8\u0ac7\u0a95 \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d0\u05e6'\u05d4'\u05e1 \u05e0\u05e7"
     ],
     "name:hin_x_preferred":[
         "\u0915\u093e\u0936\u093e\u091c\u093c \u0928\u0947\u0915 \u091c\u093f\u0932\u093e"
@@ -95,6 +104,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce74\ucc28\uc2a4\ub124\ud06c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uce74\ucc28\uc2a4\ub124\ud06c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Kachasnekas distrikts"
@@ -161,6 +173,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u67e5\u65af\u5167\u514b\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Qacha's Nek"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -282,7 +297,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938595,
     "wof:name":"Qacha's Nek",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/57/85673857.geojson
+++ b/data/856/738/57/85673857.geojson
@@ -89,6 +89,9 @@
     "name:hun_x_preferred":[
         "Thaba-Tseka"
     ],
+    "name:hye_x_preferred":[
+        "\u0539\u0561\u0562\u0561-\u0551\u0565\u056f\u0561"
+    ],
     "name:ind_x_preferred":[
         "Distrik Thaba-Tseka"
     ],
@@ -106,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud0c0\ubc14\uccb4\uce74 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud0c0\ubc14\uccb4\uce74\uad6c"
     ],
     "name:lav_x_preferred":[
         "Thabacekas distrikts"
@@ -169,6 +175,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5854\u5df4-\u91c7\u5361\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Thaba-Tseka"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -290,7 +299,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501494,
+    "wof:lastmodified":1690938595,
     "wof:name":"Thaba-Tseka",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/61/85673861.geojson
+++ b/data/856/738/61/85673861.geojson
@@ -41,6 +41,9 @@
     "name:bul_x_preferred":[
         "\u041c\u0430\u0444\u0435\u0442\u0435\u043d\u0433"
     ],
+    "name:cat_x_preferred":[
+        "Mafeteng"
+    ],
     "name:ceb_x_preferred":[
         "Mafeteng District"
     ],
@@ -62,6 +65,9 @@
     "name:est_x_preferred":[
         "Mafetengi ringkond"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0645\u0627\u0641\u062a\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Mafeteng"
     ],
@@ -77,6 +83,9 @@
     "name:guj_x_preferred":[
         "\u0aae\u0abe\u0aab\u0ac7\u0a9f\u0ac7\u0a82\u0a97 \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e4\u05d8\u05e0\u05d2"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u093e\u092b\u0947\u091f\u0947\u0902\u0917 \u091c\u093f\u0932\u093e"
     ],
@@ -85,6 +94,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0544\u0561\u0586\u0565\u0569\u0565\u0576\u0563"
+    ],
+    "name:hye_x_variant":[
+        "\u0544\u0561\u0586\u0565\u057f\u0565\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Distrik Mafeteng"
@@ -103,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub9c8\ud398\ud161 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub9c8\ud398\ud161\uad6c"
     ],
     "name:lav_x_preferred":[
         "Mafetenas distrikts"
@@ -166,6 +181,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u8cbb\u6ed5\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Mafeteng"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LSO",
@@ -287,7 +305,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1636501493,
+    "wof:lastmodified":1690938595,
     "wof:name":"Mafeteng",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/890/433/499/890433499.geojson
+++ b/data/890/433/499/890433499.geojson
@@ -22,6 +22,9 @@
     "name:afr_x_preferred":[
         "Qacha's Nek"
     ],
+    "name:ast_x_preferred":[
+        "Qacha's Nek"
+    ],
     "name:ceb_x_preferred":[
         "Qacha's Nek"
     ],
@@ -37,6 +40,9 @@
     "name:frr_x_preferred":[
         "Qacha's Nek"
     ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d0\u05e6'\u05d4'\u05e1 \u05e0\u05e7"
+    ],
     "name:ita_x_preferred":[
         "Qacha's Nek"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:lit_x_preferred":[
         "Cga\u010das Nekas"
+    ],
+    "name:nau_x_preferred":[
+        "Qacha's Nek"
     ],
     "name:nld_x_preferred":[
         "Qacha's Nek"
@@ -84,6 +93,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u67e5\u65af\u5167\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Qacha's Nek"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Africa",
@@ -206,7 +218,7 @@
         }
     ],
     "wof:id":890433499,
-    "wof:lastmodified":1566596494,
+    "wof:lastmodified":1690938601,
     "wof:name":"Qacha\u2019s Nek",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/441/287/890441287.geojson
+++ b/data/890/441/287/890441287.geojson
@@ -25,10 +25,19 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0627\u062a\u064a\u0627\u0646\u064a\u0646\u063a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0627\u062a\u064a\u0627\u0646\u064a\u0646\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09c7\u09df\u09be\u09a4\u09c7\u0987\u09df\u09be\u0999\u09cd\u0997\u09c7\u0982"
     ],
     "name:bre_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:cat_x_preferred":[
         "Teyateyaneng"
     ],
     "name:ceb_x_preferred":[
@@ -45,6 +54,9 @@
     ],
     "name:fas_x_preferred":[
         "\u062a\u06cc\u0627\u062a\u06cc\u0627\u0646\u0646\u06af"
+    ],
+    "name:fin_x_preferred":[
+        "Teyateyaneng"
     ],
     "name:fra_x_preferred":[
         "Teyateyaneng"
@@ -63,6 +75,9 @@
     ],
     "name:hun_x_preferred":[
         "Teyateyaneng"
+    ],
+    "name:hye_x_preferred":[
+        "\u054f\u0565\u0575\u0561\u057f\u0565\u0575\u0561\u0576\u0565\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Teyateyaneng"
@@ -83,6 +98,12 @@
         "Teyateyaneng"
     ],
     "name:nob_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:nso_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:nya_x_preferred":[
         "Teyateyaneng"
     ],
     "name:pol_x_preferred":[
@@ -106,6 +127,9 @@
     "name:swe_x_preferred":[
         "Teyateyaneng"
     ],
+    "name:tum_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:tur_x_preferred":[
         "Teyateyaneng"
     ],
@@ -118,8 +142,17 @@
     "name:vie_x_preferred":[
         "Teyateyaneng"
     ],
+    "name:war_x_preferred":[
+        "Teyateyaneng"
+    ],
+    "name:xho_x_preferred":[
+        "Teyateyaneng"
+    ],
     "name:zho_x_preferred":[
         "\u6cf0\u4e9e\u6cf0\u4e9e\u5ae9"
+    ],
+    "name:zul_x_preferred":[
+        "Teyateyaneng"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Lesotho",
@@ -246,7 +279,7 @@
         }
     ],
     "wof:id":890441287,
-    "wof:lastmodified":1636501497,
+    "wof:lastmodified":1690938601,
     "wof:name":"Teyateyaneng",
     "wof:parent_id":85673823,
     "wof:placetype":"locality",

--- a/data/890/443/549/890443549.geojson
+++ b/data/890/443/549/890443549.geojson
@@ -22,6 +22,12 @@
     "name:afr_x_preferred":[
         "Thaba-Tseka"
     ],
+    "name:ast_x_preferred":[
+        "Thaba-Tseka"
+    ],
+    "name:ceb_x_preferred":[
+        "Thaba-Tseka"
+    ],
     "name:deu_x_preferred":[
         "Thaba-Tseka"
     ],
@@ -55,6 +61,9 @@
     "name:lit_x_preferred":[
         "Taba Ceka"
     ],
+    "name:nau_x_preferred":[
+        "Thaba-Tseka"
+    ],
     "name:nld_x_preferred":[
         "Thaba-Tseka"
     ],
@@ -79,11 +88,17 @@
     "name:spa_x_preferred":[
         "Thaba-Tseka"
     ],
+    "name:swe_x_preferred":[
+        "Thaba-Tseka"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0431\u0430-\u0426\u0435\u043a\u0430"
     ],
     "name:zho_x_preferred":[
         "\u5854\u5df4\u91c7\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Thaba-Tseka"
     ],
     "qs:name":"Thaba-Tseka",
     "qs:photos_9r":0,
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":890443549,
-    "wof:lastmodified":1636501498,
+    "wof:lastmodified":1690938601,
     "wof:name":"Thaba-Tseka",
     "wof:parent_id":85673857,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.