### PR TITLE
ls concordances, placetype local, and more

### DIFF
--- a/data/421/172/047/421172047.geojson
+++ b/data/421/172/047/421172047.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421172047,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Malingoaneng",
     "wof:parent_id":85673839,
     "wof:placetype":"county",

--- a/data/421/173/317/421173317.geojson
+++ b/data/421/173/317/421173317.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421173317,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887129,
     "wof:name":"Qeme",
     "wof:parent_id":85673827,
     "wof:placetype":"county",

--- a/data/421/177/303/421177303.geojson
+++ b/data/421/177/303/421177303.geojson
@@ -156,7 +156,7 @@
         }
     ],
     "wof:id":421177303,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887148,
     "wof:name":"Butha-Buthe",
     "wof:parent_id":85673839,
     "wof:placetype":"county",

--- a/data/421/181/311/421181311.geojson
+++ b/data/421/181/311/421181311.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421181311,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Mechechane",
     "wof:parent_id":85673839,
     "wof:placetype":"county",

--- a/data/421/181/313/421181313.geojson
+++ b/data/421/181/313/421181313.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421181313,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Mants'onyane",
     "wof:parent_id":85673857,
     "wof:placetype":"county",

--- a/data/421/183/949/421183949.geojson
+++ b/data/421/183/949/421183949.geojson
@@ -112,7 +112,7 @@
     },
     "wof:country":"LS",
     "wof:created":1459009396,
-    "wof:geomhash":"c3fe661b003fc70074d2d9843531dec2",
+    "wof:geomhash":"d556d02e7b2fceb96f490e31b7e8ab1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +122,7 @@
         }
     ],
     "wof:id":421183949,
-    "wof:lastmodified":1690938600,
+    "wof:lastmodified":1695886953,
     "wof:name":"Maletsunyane",
     "wof:parent_id":85673857,
     "wof:placetype":"county",

--- a/data/421/184/211/421184211.geojson
+++ b/data/421/184/211/421184211.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421184211,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Maama",
     "wof:parent_id":85673827,
     "wof:placetype":"county",

--- a/data/421/185/631/421185631.geojson
+++ b/data/421/185/631/421185631.geojson
@@ -411,7 +411,7 @@
         }
     ],
     "wof:id":421185631,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887148,
     "wof:name":"Maseru",
     "wof:parent_id":85673827,
     "wof:placetype":"county",

--- a/data/421/191/403/421191403.geojson
+++ b/data/421/191/403/421191403.geojson
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":421191403,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mokhotlong",
     "wof:parent_id":85673847,
     "wof:placetype":"county",

--- a/data/421/191/519/421191519.geojson
+++ b/data/421/191/519/421191519.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421191519,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Matelile",
     "wof:parent_id":85673861,
     "wof:placetype":"county",

--- a/data/856/321/73/85632173.geojson
+++ b/data/856/321/73/85632173.geojson
@@ -1132,6 +1132,7 @@
         "hasc:id":"LS",
         "icao:code":"7P",
         "ioc:id":"LES",
+        "iso:code":"LS",
         "itu:id":"LSO",
         "loc:id":"n80049717",
         "m49:code":"426",
@@ -1146,6 +1147,7 @@
         "wk:page":"Lesotho",
         "wmo:id":"LS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
     "wof:country_alpha3":"LSO",
     "wof:geom_alt":[
@@ -1168,7 +1170,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1694639535,
+    "wof:lastmodified":1695881192,
     "wof:name":"Lesotho",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/738/23/85673823.geojson
+++ b/data/856/738/23/85673823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191656,
-    "geom:area_square_m":2069135100.006993,
+    "geom:area_square_m":2069133983.55559,
     "geom:bbox":"27.510686,-29.373401,28.285747,-28.937355",
     "geom:latitude":-29.178904,
     "geom:longitude":27.922885,
@@ -284,14 +284,16 @@
         "gn:id":932932,
         "gp:id":20069865,
         "hasc:id":"LS.BE",
+        "iso:code":"LS-D",
         "iso:id":"LS-D",
         "qs_pg:id":1180916,
         "unlc:id":"LS-D",
         "wd:id":"Q737086",
         "wk:page":"Berea District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"1b490907bb6bc4d5c86a1ce614085564",
+    "wof:geomhash":"4416a558c6e835ff5c8a4f667dd6c5a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -308,7 +310,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938597,
+    "wof:lastmodified":1695884884,
     "wof:name":"Berea",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/27/85673827.geojson
+++ b/data/856/738/27/85673827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.357172,
-    "geom:area_square_m":3841762543.421216,
+    "geom:area_square_m":3841762936.161569,
     "geom:bbox":"27.300307,-29.926959,28.203374,-29.264622",
     "geom:latitude":-29.55677,
     "geom:longitude":27.797955,
@@ -284,14 +284,16 @@
         "gn:id":932506,
         "gp:id":20069870,
         "hasc:id":"LS.MS",
+        "iso:code":"LS-A",
         "iso:id":"LS-A",
         "qs_pg:id":241491,
         "unlc:id":"LS-A",
         "wd:id":"Q844921",
         "wk:page":"Maseru District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"422770427070a7215a4c598c6ff55799",
+    "wof:geomhash":"e839749f56632cdab3366005d1deb299",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -308,7 +310,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938596,
+    "wof:lastmodified":1695884884,
     "wof:name":"Maseru",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/29/85673829.geojson
+++ b/data/856/738/29/85673829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.31241,
-    "geom:area_square_m":3343047867.703972,
+    "geom:area_square_m":3343048829.044369,
     "geom:bbox":"27.17135,-30.393425,28.554671,-29.776218",
     "geom:latitude":-30.071154,
     "geom:longitude":27.761107,
@@ -279,14 +279,16 @@
         "gn:id":932439,
         "gp:id":20069868,
         "hasc:id":"LS.MH",
+        "iso:code":"LS-F",
         "iso:id":"LS-F",
         "qs_pg:id":1099764,
         "unlc:id":"LS-F",
         "wd:id":"Q839074",
         "wk:page":"Mohale's Hoek District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"aeb37ea0c31a522e622374c472e1ffce",
+    "wof:geomhash":"2c96ba3708f278105f06addf0e15188e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938596,
+    "wof:lastmodified":1695884884,
     "wof:name":"Mohale's Hoek",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/33/85673833.geojson
+++ b/data/856/738/33/85673833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266969,
-    "geom:area_square_m":2848664199.044992,
+    "geom:area_square_m":2848663271.683598,
     "geom:bbox":"27.533364,-30.658799,28.355596,-30.001269",
     "geom:latitude":-30.351354,
     "geom:longitude":27.965682,
@@ -281,14 +281,16 @@
         "gn:id":932184,
         "gp:id":20069867,
         "hasc:id":"LS.QT",
+        "iso:code":"LS-G",
         "iso:id":"LS-G",
         "qs_pg:id":69950,
         "unlc:id":"LS-G",
         "wd:id":"Q839060",
         "wk:page":"Quthing District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"a76bda5f96f87fd7d7519187758c5fd9",
+    "wof:geomhash":"c975c064f20aaf16ae057e8b890decd8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938596,
+    "wof:lastmodified":1695884884,
     "wof:name":"Quthing",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/39/85673839.geojson
+++ b/data/856/738/39/85673839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158777,
-    "geom:area_square_m":1720464520.106067,
+    "geom:area_square_m":1720464530.847322,
     "geom:bbox":"28.218116,-29.072644,28.830881,-28.570761",
     "geom:latitude":-28.799762,
     "geom:longitude":28.563809,
@@ -278,14 +278,16 @@
         "gn:id":932888,
         "gp:id":20069862,
         "hasc:id":"LS.BB",
+        "iso:code":"LS-B",
         "iso:id":"LS-B",
         "qs_pg:id":1180821,
         "unlc:id":"LS-B",
         "wd:id":"Q535632",
         "wk:page":"Butha-Buthe District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"04f1a49c8dddbeb07bf543fe66d3eb9b",
+    "wof:geomhash":"ceeb2a480658756d051825390b014bc8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -302,7 +304,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938597,
+    "wof:lastmodified":1695884884,
     "wof:name":"Butha-Buthe",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/43/85673843.geojson
+++ b/data/856/738/43/85673843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250343,
-    "geom:area_square_m":2707340034.182842,
+    "geom:area_square_m":2707341700.415996,
     "geom:bbox":"27.630747,-29.346064,28.791297,-28.700652",
     "geom:latitude":-29.002628,
     "geom:longitude":28.273228,
@@ -281,14 +281,16 @@
         "gn:id":932700,
         "gp:id":20069863,
         "hasc:id":"LS.LE",
+        "iso:code":"LS-C",
         "iso:id":"LS-C",
         "qs_pg:id":1180826,
         "unlc:id":"LS-C",
         "wd:id":"Q819987",
         "wk:page":"Leribe District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"e62b0ff723992ff827a526f560c2203f",
+    "wof:geomhash":"dcdf72eb2261bb564baba9134053c9b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938596,
+    "wof:lastmodified":1695884884,
     "wof:name":"Leribe",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/47/85673847.geojson
+++ b/data/856/738/47/85673847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355944,
-    "geom:area_square_m":3841057966.370812,
+    "geom:area_square_m":3841059755.434922,
     "geom:bbox":"28.562112,-29.576024,29.435908,-28.759534",
     "geom:latitude":-29.225008,
     "geom:longitude":29.022071,
@@ -275,14 +275,16 @@
         "gn:id":932418,
         "gp:id":20069861,
         "hasc:id":"LS.MK",
+        "iso:code":"LS-J",
         "iso:id":"LS-J",
         "qs_pg:id":241470,
         "unlc:id":"LS-J",
         "wd:id":"Q817340",
         "wk:page":"Mokhotlong District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"b97c3b2600c8fb81a79b70f1ae1b5164",
+    "wof:geomhash":"6034dbd9306e438bd516027524013a81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938597,
+    "wof:lastmodified":1695884884,
     "wof:name":"Mokhotlong",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/51/85673851.geojson
+++ b/data/856/738/51/85673851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18905,
-    "geom:area_square_m":2025032024.563877,
+    "geom:area_square_m":2025031656.620021,
     "geom:bbox":"28.203374,-30.17324,29.150654,-29.738805",
     "geom:latitude":-29.971309,
     "geom:longitude":28.694821,
@@ -273,14 +273,16 @@
         "gn:id":932219,
         "gp:id":20069866,
         "hasc:id":"LS.QN",
+        "iso:code":"LS-H",
         "iso:id":"LS-H",
         "qs_pg:id":1181044,
         "unlc:id":"LS-H",
         "wd:id":"Q850423",
         "wk:page":"Qacha's Nek District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"23d2b2e2e53c89e7e81f5341860cd6f7",
+    "wof:geomhash":"d4d607716887a8141cb6fbaefebd4a22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -297,7 +299,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938595,
+    "wof:lastmodified":1695884884,
     "wof:name":"Qacha's Nek",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/57/85673857.geojson
+++ b/data/856/738/57/85673857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.470439,
-    "geom:area_square_m":5059579721.462647,
+    "geom:area_square_m":5059578578.170315,
     "geom:bbox":"28.100022,-29.894402,29.296279,-29.10582",
     "geom:latitude":-29.566233,
     "geom:longitude":28.595858,
@@ -275,14 +275,16 @@
         "gn:id":932011,
         "gp:id":20069864,
         "hasc:id":"LS.TT",
+        "iso:code":"LS-K",
         "iso:id":"LS-K",
         "qs_pg:id":69869,
         "unlc:id":"LS-K",
         "wd:id":"Q817327",
         "wk:page":"Thaba-Tseka District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"55c60cd30e75f55d8ad06731d3083334",
+    "wof:geomhash":"19580a055d5c50703c71fd3a04a841f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938595,
+    "wof:lastmodified":1695884884,
     "wof:name":"Thaba-Tseka",
     "wof:parent_id":85632173,
     "wof:placetype":"region",

--- a/data/856/738/61/85673861.geojson
+++ b/data/856/738/61/85673861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250581,
-    "geom:area_square_m":2689034246.012911,
+    "geom:area_square_m":2689034275.193388,
     "geom:bbox":"27.002155,-30.040802,28.309621,-29.52012",
     "geom:latitude":-29.788824,
     "geom:longitude":27.514151,
@@ -281,14 +281,16 @@
         "gn:id":932615,
         "gp:id":20069869,
         "hasc:id":"LS.MF",
+        "iso:code":"LS-E",
         "iso:id":"LS-E",
         "qs_pg:id":241490,
         "unlc:id":"LS-E",
         "wd:id":"Q817342",
         "wk:page":"Mafeteng District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LS",
-    "wof:geomhash":"3581f89bf2f9bc5a23c794fc362e8e60",
+    "wof:geomhash":"1e716718476fa3641d3b59dd5a69aca1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
         "sot",
         "eng"
     ],
-    "wof:lastmodified":1690938595,
+    "wof:lastmodified":1695884883,
     "wof:name":"Mafeteng",
     "wof:parent_id":85632173,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.